### PR TITLE
DockerStep variable checking after before-block

### DIFF
--- a/src/pipeline/DockerStepModel.groovy
+++ b/src/pipeline/DockerStepModel.groovy
@@ -27,19 +27,21 @@ class DockerStepModel extends AbstractStepModel {
 
 		def steps=globals.steps
 
-		def imageName=this.imageName
-
-		if (!imageName) {
-			steps.error("Docker imageName is not set!")
-		}
-
-		if (!tag) {
-			tag(globals.gitInfo.name)
-			steps.echo("Docker tag is not set. Using '${tag}' derived from git tag or branch")
-		}
 
 		def body={
 			runBeforeScripts(config,globals)
+
+			// to allow variable setting inside before block check after runBefore
+			def imageName=this.imageName
+			if (!imageName) {
+				steps.error("Docker imageName is not set!")
+			}
+
+			if (!tag) {
+				tag(globals.gitInfo.name)
+				steps.echo("Docker tag is not set. Using '${tag}' derived from git tag or branch")
+			}
+
 			steps.echo("Building docker image '${imageName}'")
 			steps.sh("docker build . -t ${imageName}:${tag}")
 			steps.echo("Pushing docker image '${imageName}' with tag '${tag}'")


### PR DESCRIPTION
Moving the check inside body allows setting variables within body of a build step (later then before).